### PR TITLE
Add 'port' to the options passed to the loadPackage function

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ const loadPackage = (url, authInfo) => new Promise((resolve, reject) => {
 	const options = {
 		host: url.hostname,
 		path: url.pathname,
+		port: url.port,
 		headers: {
 			accept: 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*'
 		}


### PR DESCRIPTION
I'm currently looking into [verdaccio](https://www.verdaccio.org/) as a local npm registry, and by default it runs on port 4873. Currently this package does grab the port from what `registry-url` returns, but doesn't pass it on to the actual get request.

I went for minimal code changes, but I guess to make absolutely sure it doesn't change for existing users, you could pass undefined if given a standard port (80 or 443).

Thanks for the libraries, zeit is awesome!