### PR TITLE
Indicate that catching is needed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,8 @@ indent_size = 8
 
 [*.md]
 trim_trailing_whitespace = false
+indent_size = 2
+tab_width = 2
 
 # Ideal settings - some plugins might support these.
 [*.js]

--- a/.editorconfig
+++ b/.editorconfig
@@ -24,8 +24,6 @@ indent_size = 8
 
 [*.md]
 trim_trailing_whitespace = false
-indent_size = 2
-tab_width = 2
 
 # Ideal settings - some plugins might support these.
 [*.js]

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ let update = null;
 
 try {
 	update = await checkForUpdate(pkg, {
-		interval: 3600000,  // For how long the latest version should be cached (default: 1 day)
-		distTag: 'canary'   // A npm distribution tag to compare the version to (default: 'latest')
+		interval: 3600000,  // For how long to cache latest version (default: 1 day)
+		distTag: 'canary'   // A npm distribution tag for comparision (default: 'latest')
 	});
 } catch (err) {
 	console.error(`Failed to check for updates: ${err}`);

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ let update = null;
 try {
 	update = await checkForUpdate(pkg);
 } catch (err) {
-    console.error(`Failed to check for updates: ${err}`);
+	console.error(`Failed to check for updates: ${err}`);
 }
 
 if (update) {
-    console.log(`The latest version is ${update.latest}. Please update!`);
+	console.log(`The latest version is ${update.latest}. Please update!`);
 }
 ```
 
@@ -55,15 +55,15 @@ let update = null;
 
 try {
 	update = await checkForUpdate(pkg, {
-    	interval: 3600000,  // For how long the latest version should be cached (default: 1 day)
-    	distTag: 'canary'   // A npm distribution tag to compare the version to (default: 'latest')
+		interval: 3600000,  // For how long the latest version should be cached (default: 1 day)
+		distTag: 'canary'   // A npm distribution tag to compare the version to (default: 'latest')
 	});
 } catch (err) {
 	console.error(`Failed to check for updates: ${err}`);
 }
 
 if (update) {
-    console.log(`The latest version is ${update.latest}. Please update!`);
+	console.log(`The latest version is ${update.latest}. Please update!`);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ const checkForUpdate = require('update-check');
 let update = null;
 
 try {
-  update = await checkForUpdate(pkg);
+	update = await checkForUpdate(pkg);
 } catch (err) {
-  console.error(`Failed to check for updates: ${err}`);
+	console.error(`Failed to check for updates: ${err}`);
 }
 
 if (update) {
-  console.log(`The latest version is ${update.latest}. Please update!`);
+	console.log(`The latest version is ${update.latest}. Please update!`);
 }
 ```
 
@@ -54,16 +54,16 @@ const checkForUpdate = require('update-check');
 let update = null;
 
 try {
-  update = await checkForUpdate(pkg, {
-    interval: 3600000,  // For how long the latest version should be cached (default: 1 day)
-    distTag: 'canary'   // A npm distribution tag to compare the version to (default: 'latest')
-   });
+	update = await checkForUpdate(pkg, {
+		interval: 3600000,  // For how long the latest version should be cached (default: 1 day)
+		distTag: 'canary'   // A npm distribution tag to compare the version to (default: 'latest')
+	});
 } catch (err) {
-  console.error(`Failed to check for updates: ${err}`);
+	console.error(`Failed to check for updates: ${err}`);
 }
 
 if (update) {
-  console.log(`The latest version is ${update.latest}. Please update!`);
+	console.log(`The latest version is ${update.latest}. Please update!`);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ const checkForUpdate = require('update-check');
 let update = null;
 
 try {
-	update = await checkForUpdate(pkg);
+  update = await checkForUpdate(pkg);
 } catch (err) {
-	console.error(`Failed to check for updates: ${err}`);
+  console.error(`Failed to check for updates: ${err}`);
 }
 
 if (update) {
-	console.log(`The latest version is ${update.latest}. Please update!`);
+  console.log(`The latest version is ${update.latest}. Please update!`);
 }
 ```
 
@@ -54,16 +54,16 @@ const checkForUpdate = require('update-check');
 let update = null;
 
 try {
-	update = await checkForUpdate(pkg, {
-		interval: 3600000,  // For how long the latest version should be cached (default: 1 day)
-		distTag: 'canary'   // A npm distribution tag to compare the version to (default: 'latest')
-	});
+  update = await checkForUpdate(pkg, {
+    interval: 3600000,  // For how long the latest version should be cached (default: 1 day)
+    distTag: 'canary'   // A npm distribution tag to compare the version to (default: 'latest')
+   });
 } catch (err) {
-	console.error(`Failed to check for updates: ${err}`);
+  console.error(`Failed to check for updates: ${err}`);
 }
 
 if (update) {
-	console.log(`The latest version is ${update.latest}. Please update!`);
+  console.log(`The latest version is ${update.latest}. Please update!`);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,19 @@ Next, initialize it.
 If there's a new update available, the package will return the content of latest version's `package.json` file:
 
 ```js
-const pkg = require('./package')
-const checkForUpdate = require('update-check')
+const pkg = require('./package');
+const checkForUpdate = require('update-check');
 
-const update = await checkForUpdate(pkg)
+let update = null;
+
+try {
+	update = await checkForUpdate(pkg);
+} catch (err) {
+    console.error(`Failed to check for updates: ${err}`);
+}
 
 if (update) {
-    console.log(`The latest version is ${update.latest}. Please update!`)
+    console.log(`The latest version is ${update.latest}. Please update!`);
 }
 ```
 
@@ -42,16 +48,22 @@ That's it! You're done.
 If you want, you can also pass options to customize the package's behavior:
 
 ```js
-const pkg = require('./package')
-const checkForUpdate = require('update-check')
+const pkg = require('./package');
+const checkForUpdate = require('update-check');
 
-const update = await checkForUpdate(pkg, {
-    interval: 3600000,  // For how long the latest version should be cached (default: 1 day)
-    distTag: 'canary'   // A npm distribution tag to compare the version to (default: 'latest')
-})
+let update = null;
+
+try {
+	update = await checkForUpdate(pkg, {
+    	interval: 3600000,  // For how long the latest version should be cached (default: 1 day)
+    	distTag: 'canary'   // A npm distribution tag to compare the version to (default: 'latest')
+	});
+} catch (err) {
+	console.error(`Failed to check for updates: ${err}`);
+}
 
 if (update) {
-    console.log(`The latest version is ${update.latest}. Please update!`)
+    console.log(`The latest version is ${update.latest}. Please update!`);
 }
 ```
 


### PR DESCRIPTION
With this PR, we show in the `README.md` file that it's important to catch errors (to cover the cases where npm is down, for example).