### PR TITLE
adds support for http_proxy and https_proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,19 +7,13 @@ const {tmpdir} = require('os');
 
 // Packages
 const registryUrl = require('registry-url');
-const ProxyAgent = require('https-proxy-agent');
+const ProxyAgent = require('proxy-agent');
 
 const writeFile = promisify(fs.writeFile);
 const mkdir = promisify(fs.mkdir);
 const readFile = promisify(fs.readFile);
 const compareVersions = (a, b) => a.localeCompare(b, 'en-US', {numeric: true});
 const encode = value => encodeURIComponent(value).replace(/^%40/, '@');
-
-const proxyAddress = process.env.https_proxy
-	|| process.env.HTTPS_PROXY
-	|| process.env.http_proxy
-	|| process.env.HTTP_PROXY;
-const proxyAgent = proxyAddress ? new ProxyAgent(proxyAddress) : undefined;
 
 const getFile = async (details, distTag) => {
 	const rootDir = tmpdir();
@@ -71,7 +65,7 @@ const updateCache = async (file, latest, lastUpdate) => {
 
 const loadPackage = (url, authInfo) => new Promise((resolve, reject) => {
 	const options = {
-		agent: proxyAgent,
+		agent: new ProxyAgent(),
 		host: url.hostname,
 		path: url.pathname,
 		port: url.port,

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const {tmpdir} = require('os');
 
 // Packages
 const registryUrl = require('registry-url');
-const ProxyAgent = require('https-proxy-agent')
+const ProxyAgent = require('https-proxy-agent');
 
 const writeFile = promisify(fs.writeFile);
 const mkdir = promisify(fs.mkdir);

--- a/index.js
+++ b/index.js
@@ -15,6 +15,12 @@ const readFile = promisify(fs.readFile);
 const compareVersions = (a, b) => a.localeCompare(b, 'en-US', {numeric: true});
 const encode = value => encodeURIComponent(value).replace(/^%40/, '@');
 
+const proxyAddress = process.env.http_proxy
+  || process.env.HTTP_PROXY
+  || process.env.https_proxy
+  || process.env.HTTPS_PROXY;
+const proxyAgent = proxyAddress ? new ProxyAgent(proxyAddress) : undefined;
+
 const getFile = async (details, distTag) => {
 	const rootDir = tmpdir();
 	const subDir = join(rootDir, 'update-check');
@@ -65,7 +71,7 @@ const updateCache = async (file, latest, lastUpdate) => {
 
 const loadPackage = (url, authInfo) => new Promise((resolve, reject) => {
 	const options = {
-		agent: new ProxyAgent(),
+		agent: proxyAgent,
 		host: url.hostname,
 		path: url.pathname,
 		port: url.port,

--- a/index.js
+++ b/index.js
@@ -7,12 +7,19 @@ const {tmpdir} = require('os');
 
 // Packages
 const registryUrl = require('registry-url');
+const ProxyAgent = require('https-proxy-agent')
 
 const writeFile = promisify(fs.writeFile);
 const mkdir = promisify(fs.mkdir);
 const readFile = promisify(fs.readFile);
 const compareVersions = (a, b) => a.localeCompare(b, 'en-US', {numeric: true});
 const encode = value => encodeURIComponent(value).replace(/^%40/, '@');
+
+const proxyAddress = process.env.https_proxy
+	|| process.env.HTTPS_PROXY
+	|| process.env.http_proxy
+	|| process.env.HTTP_PROXY;
+const proxyAgent = proxyAddress ? new ProxyAgent(proxyAddress) : undefined;
 
 const getFile = async (details, distTag) => {
 	const rootDir = tmpdir();
@@ -64,6 +71,7 @@ const updateCache = async (file, latest, lastUpdate) => {
 
 const loadPackage = (url, authInfo) => new Promise((resolve, reject) => {
 	const options = {
+		agent: proxyAgent,
 		host: url.hostname,
 		path: url.pathname,
 		port: url.port,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "pre-commit": "lint-staged"
   },
   "dependencies": {
+    "https-proxy-agent": "2.2.1",
     "registry-auth-token": "3.3.2",
     "registry-url": "3.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pre-commit": "lint-staged"
   },
   "dependencies": {
-    "https-proxy-agent": "2.2.1",
+    "proxy-agent": "^3.0.3",
     "registry-auth-token": "3.3.2",
     "registry-url": "3.1.0"
   }


### PR DESCRIPTION
Hi there,

this pull request is preparing support for proxies in `now-cli` (https://github.com/zeit/now-cli/issues/255). I tested it behind a corporate proxy.

Cheers,
Martin