### PR TITLE
Prevent unhandled promise rejections

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const getFile = async (details, distTag) => {
 	const subDir = join(rootDir, 'update-check');
 
 	if (!fs.existsSync(subDir)) {
-		mkdir(subDir);
+		await mkdir(subDir);
 	}
 
 	let name = `${details.name}-${distTag}.json`;


### PR DESCRIPTION
Like this, we're preventing the following error to be an unhandled promise rejection:

```
Error: EEXIST: file already exists, mkdir '/var/folders/tn/z5cj7zlj7ss86lvk7tt580180000gn/T/update-check'
```