### PR TITLE
Fix invalid request timeout error and allows to set timeout

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,9 @@ export interface Config {
 
 	/** An npm distribution tag for comparision (default: 'latest') */
 	distTag?: string;
+
+	/** Allows to set timeout for the request */
+	timeout?: number;
 }
 
 export interface Result {

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ const loadPackage = (url, authInfo) => new Promise((resolve, reject) => {
 				reject(e);
 			}
 		});
-	}).on('error', reject).on('timeout', reject);
+	}).on('error', reject).on('timeout', () => reject(new Error('Request timeout')));
 });
 
 const getMostRecent = async ({full, scope}, distTag) => {


### PR DESCRIPTION
While using I found `timeout` event has an `undefined` parameter and `try / catch` in `getMostRecent` function will throw a below error:
```js
Uncaught TypeError: Cannot read property 'code' of undefined
```

I fixed by throw a new error on `timeout` event and allows to set timeout.