### PR TITLE
X handle has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ if (update) {
 
 ## Author
 
-Leo Lamprecht ([@notquiteleo](https://twitter.com/notquiteleo)) - [ZEIT](https://zeit.co)
+Leo Lamprecht ([@notquiteleo](https://x.com/leo)) - [Vercel](https://vercel.com)
 


### PR DESCRIPTION
Twitter was renamed to X and my X handle changed from `@notquiteleo` to `@leo`.

This change replaces the previous broken link with the new working link.